### PR TITLE
Add educational README guides for video sketches

### DIFF
--- a/AsciiVideo_MiM/README.md
+++ b/AsciiVideo_MiM/README.md
@@ -1,0 +1,29 @@
+# AsciiVideo_MiM
+
+Render your face as a stream of punky ASCII glyphs and learn how to wrangle pixel brightness into characters.
+
+## Intent
+- Explore how to capture live webcam frames in Processing and map brightness to text characters.
+- Demonstrate smoothing techniques so the glyph grid doesn’t flicker itself into chaos.
+- Provide a ready-made bug hunt (`if (reset = true)` anyone?) to talk about assignment vs. comparison in conditionals.
+
+## Ingredients
+- **Libraries:** `processing.video`.
+- **Hardware:** Any webcam recognized by Processing.
+- **Assets:** The `data/` folder includes `Monospaced-48.vlw` and `UniversLTStd-Light-48.vlw`. The code currently calls `loadFont("Moospaced-48.vlw")`, so rename the file or update the line to make them match—another sneaky teachable bug.
+
+## Run it
+1. Open `AsciiVideo_MiM.pde` in Processing.
+2. Confirm the **Video** library is installed and grant webcam access when prompted.
+3. Hit Run and watch the glyphs stream in real time. Every minute the sketch *tries* to `saveFrame()`—because of the `if (reset = true)` typo the timer resets constantly, so use it to discuss debugging instead of relying on it.
+
+## How it works
+- `Capture video = new Capture(this, 160, 120);` grabs a low-res feed to keep the ASCII grid manageable.
+- The `letterOrder` string sorts characters from light to dense. During `setup()` the sketch maps each 0–255 brightness level to the appropriate char.
+- Each frame, `pixelBright` takes the max RGB component, `bright[index]` smooths the change with a 0.1 lerp, and the character is drawn with the original pixel color for extra flair.
+- The timing block at the end shows how to track elapsed minutes and seconds—while also illustrating why `==` matters.
+
+## Remix it
+- Swap in a custom font (drop a `.vlw` in `data/` and change `loadFont`).
+- Replace `max(r, g, b)` with a proper luma calculation (`0.2126*r + 0.7152*g + 0.0722*b`) and compare the results.
+- Fix the timer bug and make the auto-save trigger on a keyboard shortcut or motion detection.

--- a/Poly_p5/README.md
+++ b/Poly_p5/README.md
@@ -1,0 +1,30 @@
+# Poly_p5
+
+An audio-reactive polygon riot that teaches how to tap the microphone with Minim and animate geometry based on amplitude.
+
+## Intent
+- Show how to use the Minim library for live audio input inside Processing.
+- Demonstrate polar coordinate drawing and iterative transforms to generate layered polygons.
+- Encourage experimentation with thresholds that keep visuals calm when the room is quiet and explosive when the beat drops.
+
+## Ingredients
+- **Libraries:** `ddf.minim` (installed via Processing’s Contribution Manager).
+- **Hardware:** Microphone or line-in source.
+- **Optional assets:** None—this one thrives on live sound.
+
+## Run it
+1. Open `Poly_p5.pde` in Processing and make sure the Minim library is available.
+2. Plug in a mic, audio interface, or loopback and grant input permissions if your OS nags you.
+3. Hit Run and make some noise. The background hue and polygon count will start mutating whenever `in.left.level()` jumps above ~0.01 (scaled to `var > 10`).
+4. Smash the `S` key whenever you want to `saveFrame()` a still.
+
+## How it works
+- `Minim minim = new Minim(this);` plus `getLineIn()` grabs stereo input; only the left channel drives `var` for simplicity.
+- When `var` crosses `10`, the sketch randomizes the polygon side count (`sides`) and background hue, then animates nested shapes via rotation (`rot`) and translation (`tran`).
+- The `move()` function maps accumulated distance (`dis`) into rotation, creating a slow spin even when the audio chills out.
+- `bow()` alternates fill and stroke colors per layer, teaching how modulo checks create visual rhythm.
+
+## Remix it
+- Swap `in.left.level()` for an FFT spectrum and map bass/mids/highs to different behaviors.
+- Animate the `strokeWeight` or `colorMode` based on BPM detection for extra chaos.
+- Route OSC or MIDI data instead of audio to turn the polygon dance into a controller visualizer.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
-# videoProcessing
- p5 video manipulation/analysis sketches
+# videoProcessing Lab Manual
+
+Welcome to the scrappy classroom where every Processing sketch is an excuse to bend light, sound, and network packets until they dance. This repo corrals a bunch of video-centric experiments so you can study how they tick, remix them for your own projects, or just vibe with the glitch.
+
+## Why this collection exists
+Each folder holds a Processing sketch that targets a specific idea: ASCII camera feeds, OSC-controlled playback, UDP streaming, VHS simulation, and more. The code might be rough around the edges (some sketches are straight-up works in progress), but that's exactly why it's useful as a teaching tool. You get to see the decisions, the mistakes, and the hacks all laid bare.
+
+## Gear up: environment and libraries
+1. **Install Processing 3.5.x or Processing 4.x.** These sketches were authored in the classic PDE and expect the Java mode runtime.
+2. **Add the following libraries through the Processing Contribution Manager unless noted otherwise:**
+   - **Video** – core webcam/movie playback for most sketches.
+   - **Minim** – audio input for `Poly_p5`.
+   - **oscP5** and **netP5** – OSC networking in `vidControl` and `vidPlay`.
+   - **OpenCV for Processing** (by Greg Borenstein) – computer-vision helpers in `bg_subMOV2`.
+   - The remaining imports rely on the Java standard library (`java.net`, `java.io`, `javax.imageio`) and ship with Processing; no extra installation needed.
+3. **Hardware checklist:**
+   - A webcam that Processing can see.
+   - A microphone or line-in source if you want to drive the audio-reactive sketches.
+   - Speakers or headphones if you're vibing with Minim.
+4. **Media assets:** drop any required `.mov`, `.mp4`, or `.jpg` files into the sketch’s `data` folder (create it when missing). The table below calls out the filenames each sketch is expecting right now.
+
+## Running the sketches
+1. Launch Processing and open the folder of the sketch you want (`File → Open...` and pick the `.pde`).
+2. Confirm the library imports at the top of the sketch match the libraries you have installed.
+3. Make sure any referenced media files exist inside a `data` subfolder next to the `.pde`.
+4. Hit the **Run** button. If the console screams about missing files or libraries, fix those first—debugging is part of the lesson.
+
+## Sketch roster at a glance
+| Folder | Theme | Key Libraries | Media + Setup Notes |
+| --- | --- | --- | --- |
+| `AsciiVideo_MiM` | Live webcam feed rendered as ASCII glyphs with a timer that tries to auto-save frames. | `processing.video` | Uses the bundled `Moospaced-48` font files. Webcam required. The auto-save logic currently resets every frame—great bug-hunting fodder. |
+| `Poly_p5` | Audio-reactive polygon swarm that rotates and morphs with input amplitude. | `ddf.minim` | Needs a microphone/line-in. Press `S` to save a frame when the visuals slap. |
+| `bg_subMOV` | Background subtraction on the webcam to drive the playback speed of `Untitled_1.mov`. | `processing.video` | Place `Untitled_1.mov` in `data/`. Movement near the camera maps to movie speed (including reverse). |
+| `bg_subMOV2` | OpenCV-powered background subtraction composited on top of a looping movie. | `processing.video`, `OpenCV for Processing` | Also expects `Untitled_1.mov`. Camera capture is wired but not started—perfect chance to teach debugging and `video.start()`. |
+| `compositeVideoSim` | Port of Jonathan Campbell’s composite-video simulator for analog VHS grime. | (core Processing only) | Set `filename`/`fileext` to a real image in `data/` before running. Heavy on image processing, so be patient. |
+| `image_streaming` | UDP-based video streaming between Processing sketches (sender + two receiver flavors). | `processing.video` | Run `VideoSender` and either `VideoReceiver` or `VideoReceiverThread`. All communication currently targets `localhost` on port `9100`. |
+| `sketch_190517a` | Randomized movie playlist with (commented) serial hooks for external triggers. | `processing.video` | Populate `data/` with numbered clips like `0.mov`…`9.mov`. The playlist loops when each movie ends. |
+| `vidControl` | Webcam motion detector that fires OSC messages describing how rowdy the scene is. | `processing.video`, `oscP5`, `netP5` | Sends OSC bundles (`none`, `tiny`, `some`, `lots`) to `127.0.0.1:12000`. Great companion to `vidPlay`. |
+| `vidPlay` | OSC-controlled movie playback that responds to the vibe levels from `vidControl`. | `processing.video`, `oscP5`, `netP5` | Supply the referenced video file (currently `ROBOTECH_REMASTERED_VOL_1_? copy.m4v`) in `data/`. Adjust the filename to match your actual asset. |
+| `videoFilters` | Keyboard-driven webcam filters for mirroring, sepia, posterization, and threshold effects. | `processing.video` | Use keys `v`, `m`, `s`, `f`, `y` to switch looks. Any other key resets to the raw feed. |
+| `videoRNDM` | Prototype for scheduling surprise video clips based on elapsed time. | `processing.video` | Set `stringNum` to a valid clip name before running—right now the sketch will crash without it. A teachable moment about initialization. |
+
+## Media file expectations
+| Sketch | Current filename(s) referenced in code | What to do |
+| --- | --- | --- |
+| `bg_subMOV`, `bg_subMOV2` | `Untitled_1.mov` | Replace with your own clip but keep the filename or update the code. Drop it inside each sketch’s `data/` folder. |
+| `vidPlay` | `ROBOTECH_REMASTERED_VOL_1_? copy.m4v` | Rename your target file to something sane and edit the `new Movie` call to match. |
+| `sketch_190517a` | `0.mov` … `9.mov` (driven by `movTOTAL`) | Provide numbered clips or tweak the selector logic. |
+| `videoRNDM` | `stringNum + ".mov"` (uninitialized) | Set `stringNum` manually before `setup()` or refactor the sketch as described in its README. |
+| `compositeVideoSim` | Image file defined by `filename`/`fileext` | Drop an image into the sketch folder and update the variables. |
+
+## How to contribute or extend
+- Clone the repo, branch locally (or live dangerously on `main`), and add your own sketch folders with their own README.
+- Document what you learn. The imperfections in these sketches are features when you explain *why* they behave that way.
+- If you fix a bug, call it out loudly so future readers know what changed and why.
+
+Now go make the pixels scream.

--- a/bg_subMOV/README.md
+++ b/bg_subMOV/README.md
@@ -1,0 +1,29 @@
+# bg_subMOV
+
+Teach background subtraction by hijacking a webcam feed to control the playback speed of a movie file.
+
+## Intent
+- Illustrate pixel-by-pixel frame differencing with arrays you manage yourself.
+- Connect computer-vision output to something tangible—in this case the playback speed of `Untitled_1.mov`.
+- Provide a sandbox for experimenting with thresholds and mapping ranges.
+
+## Ingredients
+- **Libraries:** `processing.video`.
+- **Hardware:** Webcam.
+- **Media:** Place a video named `Untitled_1.mov` inside the sketch’s `data/` folder.
+
+## Run it
+1. Copy your clip into `data/Untitled_1.mov` (or update the filename in the code).
+2. Open `bg_subMOV.pde` in Processing with the Video library installed.
+3. Hit Run. The background starts empty; as soon as the first frame arrives the sketch stores it in `backgroundPixels`.
+4. Move in front of the camera to bump `presenceSum`. That sum gets mapped to `mov1.speed(newSpeed)` between `-0.5` (rewind) and `2.5` (fast forward).
+
+## How it works
+- The loop over `numPixels` computes absolute differences between the current and stored background RGB values, accumulating them into `presenceSum` while also writing a visualization of the difference into the sketch window.
+- `backgroundPixels[i] = currColor;` effectively turns this into a *running frame difference* instead of a true static background. Discuss why the motion trail fades quickly and how you might capture a static background snapshot instead.
+- After the pixels update, the movie is drawn and its speed is remapped by `map(presenceSum, 1000000, 99999999, -0.5, 2.5);`. Those bounds are intentionally huge, which is a great prompt to talk about calibration.
+
+## Remix it
+- Replace `map(...)` with `constrain()` + normalized values to make the controls more predictable.
+- Store a rolling average of `presenceSum` to smooth out jitters.
+- Use OSC or MIDI instead of direct video playback so motion controls external instruments.

--- a/bg_subMOV2/README.md
+++ b/bg_subMOV2/README.md
@@ -1,0 +1,30 @@
+# bg_subMOV2
+
+A background-subtraction experiment that layers OpenCV motion masks over a looping movie.
+
+## Intent
+- Introduce the OpenCV for Processing bindings and their background subtraction helper.
+- Combine live camera analysis with pre-recorded footage for quick compositing tricks.
+- Highlight the importance of starting captures and handling asynchronous video events.
+
+## Ingredients
+- **Libraries:** `processing.video`, `gab.opencv` (a.k.a. OpenCV for Processing).
+- **Hardware:** Webcam.
+- **Media:** Provide `data/Untitled_1.mov` or edit the movie filename.
+
+## Run it
+1. Install the OpenCV for Processing library (search for "OpenCV" inside the Contribution Manager).
+2. Copy your target movie into `data/Untitled_1.mov` or tweak the constructor.
+3. Open `bg_subMOV2.pde` in Processing.
+4. Add `video.start();` inside `setup()` before running—without it, the capture never feeds frames to OpenCV. Treat this as an intentional teaching moment.
+5. Run the sketch. You’ll see the movie playing while any contours detected by OpenCV (once you uncomment that block) can be drawn over it.
+
+## How it works
+- `opencv.startBackgroundSubtraction(5, 3, 0.5);` initializes a Mixture of Gaussians background model with adjustable history, n-mixtures, and learning rate.
+- Each `draw()` cycle calls `opencv.loadImage(video);`, which pulls the latest camera frame into the OpenCV buffer (assuming you started the capture and implement `captureEvent` or rely on lazy reads).
+- The contour loop is commented out. Uncommenting it will iterate over detected motion blobs and outline them with `stroke(255, 0, 0);`.
+
+## Remix it
+- Replace the contour draw with `opencv.getOutput();` and alpha-blend the mask onto the movie for a proper composite.
+- Experiment with `opencv.updateBackground();` toggled on/off to see how a static vs. adaptive background behaves.
+- Route the contour count to OSC or MIDI to control other sketches.

--- a/compositeVideoSim/README.md
+++ b/compositeVideoSim/README.md
@@ -1,0 +1,28 @@
+# compositeVideoSim
+
+Simulate the crunchy path an analog composite signal takes through VHS decks, complete with chroma bleed and scanlines.
+
+## Intent
+- Showcase how to port complex image-processing pipelines into Processing.
+- Provide a guided tour through composite video theory: YIQ conversion, QAM modulation, noise injection, and scanline rendering.
+- Offer a batch-processing hook for turning a whole folder of images into glitch art.
+
+## Ingredients
+- **Libraries:** Core Processing (no external dependencies).
+- **Assets:** Supply the image you want to mangle and point the sketch at it via the `filename` and `fileext` variables. Default expects `test.jpg` in the sketch root (or inside `./` relative to the PDE).
+
+## Run it
+1. Place your source image alongside `compositeVideoSim.pde` (or inside a `foldername` you set in code).
+2. Open the sketch in Processing and edit the config block near the top if you want to change `filename`, tweak noise levels, or enable/disable steps.
+3. Run the sketch. Processing resizes the window to `max_display_size` and begins the 19-step signal simulation.
+4. Press the **spacebar** to save the processed result. Hit `b` to trigger batch mode, which will churn through every image in `foldername`.
+
+## How it works
+- The `composite_layer` function converts RGB pixels to YIQ, runs them through chroma low-pass filters, packs them into a simulated composite waveform, then demodulates with optional VHS FM noise.
+- Config flags like `composite_in_chroma_lowpass`, `vhs_svideo_out`, and `video_recombine` let you toggle sections without editing the core loop—great for teaching modular pipelines.
+- `renderScanLines()` adds RGB scanlines if `scanlines_scale > 1`, reinforcing how analog displays interleaved color information.
+
+## Remix it
+- Feed the output back into the input for recursive degradation.
+- Swap the noise models for your own custom functions to mimic camcorder glitches or broadcast interference.
+- Pair the batch processor with a folder of webcam grabs to create a time-lapse of analog decay.

--- a/image_streaming/README.md
+++ b/image_streaming/README.md
@@ -1,0 +1,37 @@
+# image_streaming
+
+A trio of sketches that teach how to fling webcam frames across UDP—both in a single Processing sketch and with a dedicated receiver thread.
+
+## Intent
+- Demonstrate how to encode a `PImage` into JPEG bytes and ship it via UDP datagrams.
+- Compare a simple blocking receive loop against a threaded receiver that decouples network I/O from rendering.
+- Provide a jumping-off point for building networked video art installations or remote monitoring tools.
+
+## Folder layout
+```
+image_streaming/
+├── VideoSender/             # Captures webcam frames and broadcasts them
+├── VideoReceiver/           # Minimal blocking UDP receiver
+└── VideoReceiverThread/     # Receiver that runs networking on a separate thread
+```
+
+## Shared ingredients
+- **Libraries:** `processing.video` (for capture) plus Java’s built-in `java.net`, `java.io`, and `javax.imageio` packages.
+- **Hardware:** Webcam.
+- **Network:** Default configuration sends to and listens on `localhost:9100`. Adjust IP/port if you want to go cross-machine.
+
+## Run the demo (single machine)
+1. Open `VideoSender/VideoSender.pde` in Processing, make sure the Video library is installed, and hit Run. The console will log the size of each outgoing datagram.
+2. In a second Processing window, open either `VideoReceiver/VideoReceiver.pde` (simpler) or `VideoReceiverThread/VideoReceiverThread.pde` (threaded) and hit Run.
+3. The receiver prints the byte count for each datagram, decodes the JPEG stream via `ImageIO.read`, and displays the frames.
+4. Stop the sender or receiver to observe how blocking I/O behaves; the threaded version keeps rendering even if packets pause.
+
+## Teaching highlights
+- `broadcast(PImage img)` constructs a `BufferedImage`, encodes it as JPEG, then pushes the raw bytes into a `DatagramPacket`. Walk through each step to demystify bridging between Processing’s pixel arrays and Java’s image codecs.
+- The basic receiver’s `checkForImage()` is intentionally blocking—great for demonstrating why UI threads should avoid long-running calls.
+- `ReceiverThread` manages state with `available` flags so the main sketch can poll for new frames without stalling.
+
+## Remix it
+- Swap JPEG for PNG or raw RGB data to discuss compression trade-offs.
+- Add rudimentary packet headers so you can drop frames gracefully when the network hiccups.
+- Extend the thread to multicast frames to multiple viewers or to write incoming images to disk.

--- a/sketch_190517a/README.md
+++ b/sketch_190517a/README.md
@@ -1,0 +1,28 @@
+# sketch_190517a
+
+A random video jukebox that hints at how to integrate serial sensors for playlist control.
+
+## Intent
+- Demonstrate movie playback in Processing and how to cycle through a folder of clips.
+- Show where you’d plug in serial data (e.g., Arduino) to trigger different playback logic.
+- Encourage learners to think about file naming, duration checks, and playlist state.
+
+## Ingredients
+- **Libraries:** `processing.video` (required), `processing.serial` (currently commented out but ready if you need it).
+- **Media:** Populate the `data/` folder with clips named `0.mov`, `1.mov`, … up to `movTOTAL - 1`. The default `movTOTAL` is `10`.
+
+## Run it
+1. Add your clips to the `data/` folder using the numbering scheme above.
+2. Open `sketch_190517a.pde` in Processing and confirm the Video library is installed.
+3. In `setup()`, either call `mov.play();` after constructing the `Movie`, or change `mov = new Movie(...);` to `mov.loop();` so the first selection actually starts. The code currently forgets to start playback—a perfect debugging exercise.
+4. Run the sketch. When a movie reaches the end (`mov.time() == mov.duration()`), `videoSelect()` picks another random file.
+
+## How it works
+- `playSelection` stores the filename. `videoSelect()` rebuilds the `Movie` object with a new random index using `nf(int(random(0, movTOTAL)))`.
+- Commented serial code shows how you could read bytes from `Serial` to trigger alternate playlists (e.g., `run()` vs. random mode).
+- Because `mov.read()` is called every frame without checking `movieEvent`, this sketch pushes you to learn about proper movie event handling.
+
+## Remix it
+- Implement `movieEvent(Movie m)` to keep the decoder happy, then gate playback on serial data or OSC.
+- Replace the random selection with weighted choices or a Markov chain for curated playlists.
+- Display on-screen UI showing which clip is playing and how much time remains.

--- a/vidControl/README.md
+++ b/vidControl/README.md
@@ -1,0 +1,29 @@
+# vidControl
+
+Motion-driven OSC controller: watch the webcam for movement and shout OSC messages based on how wild things get.
+
+## Intent
+- Teach manual frame differencing and accumulation to quantify scene activity.
+- Demonstrate how to send OSC messages from Processing using `oscP5`/`netP5`.
+- Pair with `vidPlay` (or any OSC-aware app) to build interactive installations.
+
+## Ingredients
+- **Libraries:** `processing.video`, `oscP5`, `netP5`.
+- **Hardware:** Webcam.
+- **Network:** Sends to `127.0.0.1` on port `12000` by default. Adjust `myRemoteLocation` if your receiver lives elsewhere.
+
+## Run it
+1. Install `oscP5` and `netP5` via the Contribution Manager (they ship together).
+2. Open `vidControl.pde` in Processing, confirm the Video library is available, and place a receiver sketch/app on port `12000`.
+3. Hit Run. The webcam feed displays in the window to help with framing.
+4. Wave around. The sketch maps `presenceSum` (sum of RGB differences across the frame) into four ranges and sends OSC messages labelled `none`, `tiny`, `some`, or `lots`.
+
+## How it works
+- Each frame, `presenceSum` accumulates the absolute difference between the current frame and the last stored `backgroundPixels`. Because the code updates `backgroundPixels[i] = currColor;` each iteration, it effectively measures per-frame change rather than difference from a static background.
+- The `map()` call squeezes `presenceSum` into 0–20. That value selects which OSC message to fire; the payload is a simple integer (`1`–`4`).
+- `frameRate(4);` throttles processing, making the OSC stream easier to digest and showing how frame rates affect responsiveness.
+
+## Remix it
+- Capture a clean background image by pressing a key, then compare future frames against that snapshot for more stable results.
+- Send the motion metrics as continuous floats instead of discrete buckets.
+- Chain in OpenCV for blob detection so you only react to specific regions of the frame.

--- a/vidPlay/README.md
+++ b/vidPlay/README.md
@@ -1,0 +1,29 @@
+# vidPlay
+
+An OSC-responsive movie player: it listens for vibe levels from `vidControl` and adjusts playback speed accordingly.
+
+## Intent
+- Demonstrate how to receive OSC messages in Processing and map them to movie playback controls.
+- Encourage modular design by pairing this sketch with an external controller (`vidControl` by default).
+- Highlight how to handle missing assets and sanitize filenames.
+
+## Ingredients
+- **Libraries:** `processing.video`, `oscP5`, `netP5`.
+- **Media:** Supply the movie referenced in `new Movie(this, "ROBOTECH_REMASTERED_VOL_1_? copy.m4v")`. Rename the file or update the string to something filesystem-friendly.
+- **Network:** Listens on port `12000` for incoming OSC messages.
+
+## Run it
+1. Place your desired video file into the sketch’s `data/` folder and update the filename in `setup()` if needed.
+2. Open `vidPlay.pde` in Processing with the Video and OSC libraries installed.
+3. Run the sketch. By default it loops the movie.
+4. Trigger OSC messages from `vidControl` (or another source) using address patterns `none`, `tiny`, `some`, and `lots`. Each message maps to a playback speed: reverse, slow, normal, and hype mode (1.85x).
+
+## How it works
+- `oscEvent(OscMessage theOscMessage)` uses `checkAddrPattern` to compare the incoming message with each expected route. When matched, it updates `newSpeed`.
+- The `draw()` loop applies `mov.speed(newSpeed);` each frame and caches `oldSpeed` so unknown messages don’t crash playback—they simply reuse the previous speed.
+- There’s no payload validation yet, so this is a good platform for adding safety checks or supporting continuous float parameters.
+
+## Remix it
+- Map OSC floats (`/speed`, `/scrub`) instead of discrete address patterns to gain finer control.
+- Display on-screen feedback for the current speed and message source.
+- Sync audio playback or route simultaneous OSC triggers to DMX/MIDI for multimedia shows.

--- a/videoFilters/README.md
+++ b/videoFilters/README.md
@@ -1,0 +1,33 @@
+# videoFilters
+
+A grab bag of webcam filter snippets for teaching pixel-level manipulation in Processing.
+
+## Intent
+- Show how to access and modify individual pixels from a `Capture` stream.
+- Demonstrate simple effects: vertical flip, horizontal mirror, sepia toning, faux "Warhol" palette, and threshold mask.
+- Encourage exploration of color spaces by flipping between RGB and HSB.
+
+## Ingredients
+- **Libraries:** `processing.video`.
+- **Hardware:** Webcam.
+
+## Run it
+1. Open `videoFilters.pde` in Processing and make sure the Video library is installed.
+2. Run the sketch and grant camera access. The default view is a raw passthrough.
+3. Smash keys to swap filters:
+   - `v` – vertical flip.
+   - `m` – horizontal mirror.
+   - `s` – sepia tint via manual channel offsets.
+   - `f` – color posterization into four tone bands (like a lo-fi Instagram filter).
+   - `y` – experimental threshold mask using HSB values.
+   - Any other key – resets to the unfiltered feed.
+
+## How it works
+- The sketch loops through every pixel on each draw, pulling values with `cam.get(i, j)` and writing back with `set(...)`. It’s not optimized, which makes it handy for discussing performance trade-offs.
+- Each filter manipulates RGB channels differently, showing how simple arithmetic can produce stylized looks.
+- The `y` key toggles to HSB mode temporarily, illustrating how to juggle multiple color spaces in one frame.
+
+## Remix it
+- Replace the nested loops with `loadPixels()`/`updatePixels()` for faster operations and show the speed difference.
+- Add keyboard commands to blend between filters instead of switching abruptly.
+- Pipe the processed pixels into a `PGraphics` buffer so you can layer typography or UI on top.

--- a/videoRNDM/README.md
+++ b/videoRNDM/README.md
@@ -1,0 +1,27 @@
+# videoRNDM
+
+Prototype timer that randomly drops surprise video clips once the clock hits a target minute/second.
+
+## Intent
+- Practice tracking elapsed time in Processing using `millis()`-adjacent helpers (`second()`, `minute()`).
+- Explore random scheduling: pick a future timestamp and trigger media when the clock catches up.
+- Encourage learners to reason about initialization order and null checks.
+
+## Ingredients
+- **Libraries:** `processing.video`.
+- **Media:** Provide a set of numbered clips (`00.mov`, `01.mov`, etc.) and set `stringNum` to a valid base name before `setup()` runs.
+
+## Run it
+1. Decide which clip should play first and set `stringNum = "00";` (for example) near the top of the sketch. Without this, `new Movie(this, stringNum+".mov")` will throw a null pointer.
+2. Drop the clips into the `data/` folder. The sketch expects zero-padded filenames when you call `nf(int(random(100)))`.
+3. Run the sketch. It captures the start time, picks `target_m` and `target_s`, and waits until the clock matches. Once triggered, it loads a new random clip and displays it.
+
+## How it works
+- `startTOTAL` and `stopTOTAL` convert minutes/seconds into a single second count so you can measure differences easily.
+- `calculate()` updates the current minute (`cm`) and second (`cs`) offset from the start.
+- When the current offset matches the random target, the sketch chooses a new random filename with `nf(int(random(100)))` and plays it. This is deliberately sparse so you can expand the scheduler logic.
+
+## Remix it
+- Replace the time-based trigger with keyboard input, OSC messages, or sensor data.
+- Store multiple target timestamps and trigger a queue of clips throughout a performance.
+- Add on-screen text showing the countdown to the next clip so the audience can anticipate the glitch.


### PR DESCRIPTION
## Summary
- replace the root README with a lab-manual style overview covering setup, libraries, and media requirements
- add detailed teaching READMEs to every sketch directory outlining intent, dependencies, run steps, and remix ideas
- call out known quirks and missing assets so learners can debug and extend each experiment

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c875fe695c832590d38b76abbede5f