### PR TITLE
Ensure OpenCV background subtraction receives fresh camera frames

### DIFF
--- a/bg_subMOV2/bg_subMOV2.pde
+++ b/bg_subMOV2/bg_subMOV2.pde
@@ -12,19 +12,24 @@ OpenCV opencv;
 void setup() {
   size(720, 480);
   mov1 = new Movie(this, "Untitled_1.mov");
-  
+
   video = new Capture(this, 720, 480);
   opencv = new OpenCV(this, 720, 480);
-  
+
   opencv.startBackgroundSubtraction(5, 3, 0.5);
-  
+
+  video.start();
+
   mov1.loop();
   mov1.play();
 }
 
 void draw() {
-  image(mov1, 0, 0);  
-  opencv.loadImage(video);
+  image(mov1, 0, 0);
+  if (video.available()) {
+    video.read();
+    opencv.loadImage(video);
+  }
   
   //opencv.updateBackground();
   
@@ -34,11 +39,16 @@ void draw() {
   noFill();
   stroke(255, 0, 0);
   strokeWeight(3);
-//  for (Contour contour : opencv.findContours()) {
-//    contour.draw();
-//  }
+  for (Contour contour : opencv.findContours()) {
+    contour.draw();
+  }
 }
 
 void movieEvent(Movie m) {
   m.read();
+}
+
+void captureEvent(Capture c) {
+  c.read();
+  opencv.loadImage(c);
 }


### PR DESCRIPTION
## Summary
- start the camera capture during setup and feed frames into OpenCV via captureEvent
- guard OpenCV image loading in draw() so it only runs when a new frame is available
- restore contour rendering on top of the movie playback

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691570034d908325bcf4c7a0e557f8c5)