### PR TITLE
Add configurable UDP video streaming with chunked frame support

### DIFF
--- a/image_streaming/VideoReceiver/FrameAssembler.pde
+++ b/image_streaming/VideoReceiver/FrameAssembler.pde
@@ -1,0 +1,119 @@
+import java.nio.*;
+
+class FrameAssembler {
+  static final int HEADER_SIZE = 14;
+
+  private int currentFrameId = -1;
+  private int totalLength = 0;
+  private int chunkCount = 0;
+  private byte[][] chunkData = new byte[0][];
+  private int[] chunkLengths = new int[0];
+  private boolean[] received = new boolean[0];
+  private int receivedCount = 0;
+  private int lastCompletedFrameId = -1;
+  private long lastUpdateMs = 0;
+
+  boolean consume(byte[] packet, int packetLength) {
+    if (packetLength < HEADER_SIZE) {
+      return false;
+    }
+
+    ByteBuffer buffer = ByteBuffer.wrap(packet, 0, packetLength);
+    buffer.order(ByteOrder.BIG_ENDIAN);
+
+    int frameId = buffer.getInt();
+    int totalLen = buffer.getInt();
+    int chunkIndex = buffer.getShort() & 0xffff;
+    int chunks = buffer.getShort() & 0xffff;
+    int payloadLength = buffer.getShort() & 0xffff;
+
+    if (chunks == 0 || payloadLength > packetLength - HEADER_SIZE) {
+      return false;
+    }
+
+    if (frameId < lastCompletedFrameId) {
+      return false;
+    }
+
+    if (currentFrameId != frameId) {
+      startFrame(frameId, totalLen, chunks);
+    } else {
+      if (totalLength != totalLen || chunkCount != chunks) {
+        startFrame(frameId, totalLen, chunks);
+      }
+    }
+
+    if (chunkIndex >= chunkCount) {
+      return false;
+    }
+
+    if (!received[chunkIndex]) {
+      byte[] payload = new byte[payloadLength];
+      System.arraycopy(packet, HEADER_SIZE, payload, 0, payloadLength);
+      chunkData[chunkIndex] = payload;
+      chunkLengths[chunkIndex] = payloadLength;
+      received[chunkIndex] = true;
+      receivedCount++;
+      lastUpdateMs = System.currentTimeMillis();
+    }
+
+    return receivedCount == chunkCount;
+  }
+
+  byte[] buildFrame() {
+    if (receivedCount != chunkCount) {
+      return null;
+    }
+
+    byte[] frame = new byte[totalLength];
+    int offset = 0;
+
+    for (int i = 0; i < chunkCount; i++) {
+      byte[] chunk = chunkData[i];
+      if (chunk == null) {
+        return null;
+      }
+      int len = chunkLengths[i];
+      if (offset + len > frame.length) {
+        len = max(0, frame.length - offset);
+      }
+      System.arraycopy(chunk, 0, frame, offset, len);
+      offset += len;
+    }
+
+    if (offset < frame.length) {
+      byte[] trimmed = new byte[offset];
+      System.arraycopy(frame, 0, trimmed, 0, offset);
+      frame = trimmed;
+    }
+
+    lastCompletedFrameId = currentFrameId;
+    reset();
+    return frame;
+  }
+
+  boolean hasExpired(int timeoutMs) {
+    return currentFrameId != -1 && (System.currentTimeMillis() - lastUpdateMs) > timeoutMs;
+  }
+
+  void reset() {
+    currentFrameId = -1;
+    totalLength = 0;
+    chunkCount = 0;
+    chunkData = new byte[0][];
+    chunkLengths = new int[0];
+    received = new boolean[0];
+    receivedCount = 0;
+  }
+
+  private void startFrame(int frameId, int totalLen, int chunks) {
+    currentFrameId = frameId;
+    totalLength = totalLen;
+    chunkCount = max(1, chunks);
+    chunkData = new byte[chunkCount][];
+    chunkLengths = new int[chunkCount];
+    received = new boolean[chunkCount];
+    receivedCount = 0;
+    lastUpdateMs = System.currentTimeMillis();
+  }
+}

--- a/image_streaming/VideoReceiver/VideoReceiver.pde
+++ b/image_streaming/VideoReceiver/VideoReceiver.pde
@@ -1,62 +1,151 @@
-
 import java.net.*;
 import java.io.*;
-import java.awt.image.*; 
+import java.awt.image.*;
 import javax.imageio.*;
+import javax.swing.*;
 
-// Port we are receiving.
-int port = 9100; 
-DatagramSocket ds; 
-// A byte array to read into (max size of 65536, could be smaller)
-byte[] buffer = new byte[65536]; 
+// Bind configuration (editable at runtime)
+String bindAddress = "0.0.0.0";
+int port = 9100;
+
+DatagramSocket ds;
+final int MAX_PACKET_SIZE = 60000;
+byte[] buffer = new byte[MAX_PACKET_SIZE];
+FrameAssembler assembler = new FrameAssembler();
 
 PImage video;
 
 void setup() {
   size(400,300);
-  try {
-    ds = new DatagramSocket(port);
-  } catch (SocketException e) {
-    e.printStackTrace();
-  } 
+  openSocket();
   video = createImage(320,240,RGB);
 }
 
- void draw() {
-  // checkForImage() is blocking, stay tuned for threaded example!
+void draw() {
   checkForImage();
 
   // Draw the image
   background(0);
   imageMode(CENTER);
   image(video,width/2,height/2);
+  drawOverlay();
+}
+
+void keyPressed() {
+  if (key == 'p' || key == 'P') {
+    promptForPort();
+  } else if (key == 'i' || key == 'I') {
+    promptForBindAddress();
+  }
+}
+
+void promptForPort() {
+  String response = JOptionPane.showInputDialog(frame, "Listen port", str(port));
+  if (response != null) {
+    try {
+      int parsed = Integer.parseInt(response.trim());
+      if (parsed > 0 && parsed <= 65535) {
+        port = parsed;
+        openSocket();
+      }
+    } catch (NumberFormatException ex) {
+      System.err.println("Invalid port: " + response);
+    }
+  }
+}
+
+void promptForBindAddress() {
+  String response = JOptionPane.showInputDialog(frame, "Bind address (0.0.0.0 for all)", bindAddress);
+  if (response != null && response.trim().length() > 0) {
+    bindAddress = response.trim();
+    openSocket();
+  }
+}
+
+void openSocket() {
+  if (ds != null) {
+    ds.close();
+    ds = null;
+  }
+  try {
+    if (bindAddress.equals("0.0.0.0")) {
+      ds = new DatagramSocket(port);
+    } else {
+      ds = new DatagramSocket(new InetSocketAddress(bindAddress, port));
+    }
+    ds.setSoTimeout(50);
+    System.out.println("Listening on " + bindAddress + ":" + port);
+  } catch (SocketException e) {
+    System.err.println("Failed to bind to " + bindAddress + ":" + port);
+    e.printStackTrace();
+  }
 }
 
 void checkForImage() {
-  DatagramPacket p = new DatagramPacket(buffer, buffer.length); 
+  if (ds == null) {
+    return;
+  }
+
+  DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+  boolean updated = false;
+
+  while (true) {
+    try {
+      ds.receive(packet);
+      if (assembler.consume(packet.getData(), packet.getLength())) {
+        byte[] frameBytes = assembler.buildFrame();
+        if (frameBytes != null && applyFrame(frameBytes)) {
+          updated = true;
+        }
+      }
+    } catch (SocketTimeoutException timeout) {
+      break;
+    } catch (IOException e) {
+      e.printStackTrace();
+      break;
+    } finally {
+      packet.setLength(buffer.length);
+    }
+  }
+
+  if (!updated && assembler.hasExpired(250)) {
+    assembler.reset();
+  }
+}
+
+boolean applyFrame(byte[] frameBytes) {
+  ByteArrayInputStream bais = new ByteArrayInputStream(frameBytes);
   try {
-    ds.receive(p);
-  } catch (IOException e) {
-    e.printStackTrace();
-  } 
-  byte[] data = p.getData();
-
-  println("Received datagram with " + data.length + " bytes." );
-
-  // Read incoming data into a ByteArrayInputStream
-  ByteArrayInputStream bais = new ByteArrayInputStream( data );
-
-  // We need to unpack JPG and put it in the PImage video
-  video.loadPixels();
-  try {
-    // Make a BufferedImage out of the incoming bytes
     BufferedImage img = ImageIO.read(bais);
-    // Put the pixels into the video PImage
+    if (img == null) {
+      return false;
+    }
+    video.loadPixels();
     img.getRGB(0, 0, video.width, video.height, video.pixels, 0, video.width);
+    video.updatePixels();
+    return true;
   } catch (Exception e) {
     e.printStackTrace();
   }
-  // Update the PImage pixels
-  video.updatePixels();
+  return false;
 }
 
+void drawOverlay() {
+  pushStyle();
+  fill(0, 180);
+  noStroke();
+  rect(0, height - 60, width, 60);
+  fill(255);
+  textAlign(LEFT, TOP);
+  text("Listening on " + bindAddress + ":" + port, 10, height - 55);
+  text("Press [I] to set bind address, [P] to set port", 10, height - 35);
+  text("Receiver stitches frame chunks together or bails fast", 10, height - 15);
+  popStyle();
+}
+
+void dispose() {
+  if (ds != null) {
+    ds.close();
+    ds = null;
+  }
+}

--- a/image_streaming/VideoReceiverThread/FrameAssembler.pde
+++ b/image_streaming/VideoReceiverThread/FrameAssembler.pde
@@ -1,0 +1,119 @@
+import java.nio.*;
+
+class FrameAssembler {
+  static final int HEADER_SIZE = 14;
+
+  private int currentFrameId = -1;
+  private int totalLength = 0;
+  private int chunkCount = 0;
+  private byte[][] chunkData = new byte[0][];
+  private int[] chunkLengths = new int[0];
+  private boolean[] received = new boolean[0];
+  private int receivedCount = 0;
+  private int lastCompletedFrameId = -1;
+  private long lastUpdateMs = 0;
+
+  boolean consume(byte[] packet, int packetLength) {
+    if (packetLength < HEADER_SIZE) {
+      return false;
+    }
+
+    ByteBuffer buffer = ByteBuffer.wrap(packet, 0, packetLength);
+    buffer.order(ByteOrder.BIG_ENDIAN);
+
+    int frameId = buffer.getInt();
+    int totalLen = buffer.getInt();
+    int chunkIndex = buffer.getShort() & 0xffff;
+    int chunks = buffer.getShort() & 0xffff;
+    int payloadLength = buffer.getShort() & 0xffff;
+
+    if (chunks == 0 || payloadLength > packetLength - HEADER_SIZE) {
+      return false;
+    }
+
+    if (frameId < lastCompletedFrameId) {
+      return false;
+    }
+
+    if (currentFrameId != frameId) {
+      startFrame(frameId, totalLen, chunks);
+    } else {
+      if (totalLength != totalLen || chunkCount != chunks) {
+        startFrame(frameId, totalLen, chunks);
+      }
+    }
+
+    if (chunkIndex >= chunkCount) {
+      return false;
+    }
+
+    if (!received[chunkIndex]) {
+      byte[] payload = new byte[payloadLength];
+      System.arraycopy(packet, HEADER_SIZE, payload, 0, payloadLength);
+      chunkData[chunkIndex] = payload;
+      chunkLengths[chunkIndex] = payloadLength;
+      received[chunkIndex] = true;
+      receivedCount++;
+      lastUpdateMs = System.currentTimeMillis();
+    }
+
+    return receivedCount == chunkCount;
+  }
+
+  byte[] buildFrame() {
+    if (receivedCount != chunkCount) {
+      return null;
+    }
+
+    byte[] frame = new byte[totalLength];
+    int offset = 0;
+
+    for (int i = 0; i < chunkCount; i++) {
+      byte[] chunk = chunkData[i];
+      if (chunk == null) {
+        return null;
+      }
+      int len = chunkLengths[i];
+      if (offset + len > frame.length) {
+        len = max(0, frame.length - offset);
+      }
+      System.arraycopy(chunk, 0, frame, offset, len);
+      offset += len;
+    }
+
+    if (offset < frame.length) {
+      byte[] trimmed = new byte[offset];
+      System.arraycopy(frame, 0, trimmed, 0, offset);
+      frame = trimmed;
+    }
+
+    lastCompletedFrameId = currentFrameId;
+    reset();
+    return frame;
+  }
+
+  boolean hasExpired(int timeoutMs) {
+    return currentFrameId != -1 && (System.currentTimeMillis() - lastUpdateMs) > timeoutMs;
+  }
+
+  void reset() {
+    currentFrameId = -1;
+    totalLength = 0;
+    chunkCount = 0;
+    chunkData = new byte[0][];
+    chunkLengths = new int[0];
+    received = new boolean[0];
+    receivedCount = 0;
+  }
+
+  private void startFrame(int frameId, int totalLen, int chunks) {
+    currentFrameId = frameId;
+    totalLength = totalLen;
+    chunkCount = max(1, chunks);
+    chunkData = new byte[chunkCount][];
+    chunkLengths = new int[chunkCount];
+    received = new boolean[chunkCount];
+    receivedCount = 0;
+    lastUpdateMs = System.currentTimeMillis();
+  }
+}

--- a/image_streaming/VideoReceiverThread/VideoReceiverThread.pde
+++ b/image_streaming/VideoReceiverThread/VideoReceiverThread.pde
@@ -3,21 +3,22 @@
 
 // A Thread using receiving UDP to receive images
 
-import java.awt.image.*; 
-import javax.imageio.*;
+import javax.swing.*;
 
 PImage video;
 ReceiverThread thread;
+String bindAddress = "0.0.0.0";
+int listenPort = 9100;
 
 void setup() {
   size(400,300);
   video = createImage(320,240,RGB);
-  thread = new ReceiverThread(video.width,video.height);
+  thread = new ReceiverThread(video.width,video.height, bindAddress, listenPort);
   thread.start();
 }
 
  void draw() {
-  if (thread.available()) {
+  if (thread != null && thread.available()) {
     video = thread.getImage();
   }
 
@@ -25,7 +26,60 @@ void setup() {
   background(0);
   imageMode(CENTER);
   image(video,width/2,height/2);
+  drawOverlay();
 }
 
+void keyPressed() {
+  if (key == 'p' || key == 'P') {
+    promptForPort();
+  } else if (key == 'i' || key == 'I') {
+    promptForBind();
+  }
+}
 
+void promptForPort() {
+  String response = JOptionPane.showInputDialog(frame, "Listen port", str(listenPort));
+  if (response != null) {
+    try {
+      int parsed = Integer.parseInt(response.trim());
+      if (parsed > 0 && parsed <= 65535) {
+        listenPort = parsed;
+        if (thread != null) {
+          thread.updateEndpoint(bindAddress, listenPort);
+        }
+      }
+    } catch (NumberFormatException ex) {
+      System.err.println("Invalid port: " + response);
+    }
+  }
+}
 
+void promptForBind() {
+  String response = JOptionPane.showInputDialog(frame, "Bind address (0.0.0.0 for all)", bindAddress);
+  if (response != null && response.trim().length() > 0) {
+    bindAddress = response.trim();
+    if (thread != null) {
+      thread.updateEndpoint(bindAddress, listenPort);
+    }
+  }
+}
+
+void drawOverlay() {
+  pushStyle();
+  fill(0, 180);
+  noStroke();
+  rect(0, height - 60, width, 60);
+  fill(255);
+  textAlign(LEFT, TOP);
+  text("Threaded rx on " + bindAddress + ":" + listenPort, 10, height - 55);
+  text("Press [I] to bind, [P] to pick a port", 10, height - 35);
+  text("Thread drops zombie frames instead of freezing", 10, height - 15);
+  popStyle();
+}
+
+void dispose() {
+  if (thread != null) {
+    thread.quit();
+    thread = null;
+  }
+}

--- a/image_streaming/VideoSender/VideoSender.pde
+++ b/image_streaming/VideoSender/VideoSender.pde
@@ -1,16 +1,25 @@
-import hypermedia.net.*;
-
 import processing.video.*;
 
 import java.net.*;
 import java.io.*;
 import javax.imageio.*;
-import java.awt.image.*; 
+import java.awt.image.*;
+import javax.swing.*;
+import java.nio.*;
 
-// This is the port we are sending to
-int clientPort = 9100; 
+// Network configuration (editable at runtime)
+String targetHost = "127.0.0.1";
+int clientPort = 9100;
+InetAddress targetAddress;
+
+// Frame chunking configuration
+final int HEADER_SIZE = 14;
+final int MAX_PACKET_SIZE = 60000;
+final int MAX_PAYLOAD = MAX_PACKET_SIZE - HEADER_SIZE;
+int frameIdCounter = 0;
+
 // This is our object that sends UDP out
-DatagramSocket ds; 
+DatagramSocket ds;
 // Capture object
 Capture cam;
 
@@ -25,6 +34,7 @@ void setup() {
   // Initialize Camera
   cam = new Capture( this, width,height,30);
   cam.start();
+  setTargetHost(targetHost);
 }
 
 void captureEvent( Capture c ) {
@@ -35,12 +45,63 @@ void captureEvent( Capture c ) {
 
 void draw() {
   image(cam,0,0);
+  drawOverlay();
 }
 
+void keyPressed() {
+  if (key == 'i' || key == 'I') {
+    promptForHost();
+  } else if (key == 'p' || key == 'P') {
+    promptForPort();
+  }
+}
 
-// Function to broadcast a PImage over UDP
-// Special thanks to: http://ubaa.net/shared/processing/udp/
-// (This example doesn't use the library, but you can!)
+void promptForHost() {
+  String newHost = JOptionPane.showInputDialog(frame, "Target host/IP", targetHost);
+  if (newHost != null && newHost.trim().length() > 0) {
+    setTargetHost(newHost.trim());
+  }
+}
+
+void promptForPort() {
+  String response = JOptionPane.showInputDialog(frame, "Target port", str(clientPort));
+  if (response != null) {
+    try {
+      int parsed = Integer.parseInt(response.trim());
+      if (parsed > 0 && parsed <= 65535) {
+        clientPort = parsed;
+        System.out.println("Streaming to " + targetHost + ":" + clientPort);
+      }
+    } catch (NumberFormatException ex) {
+      System.err.println("Invalid port: " + response);
+    }
+  }
+}
+
+void setTargetHost(String host) {
+  try {
+    targetAddress = InetAddress.getByName(host);
+    targetHost = host;
+    System.out.println("Streaming to " + targetHost + ":" + clientPort);
+  } catch (UnknownHostException e) {
+    System.err.println("Could not resolve host: " + host);
+  }
+}
+
+void drawOverlay() {
+  pushStyle();
+  fill(0, 180);
+  noStroke();
+  rect(0, height - 60, width, 60);
+  fill(255);
+  textAlign(LEFT, TOP);
+  text("Streaming to " + targetHost + ":" + clientPort, 10, height - 55);
+  text("Press [I] to set host, [P] to set port", 10, height - 35);
+  text("UDP chunks w/ frame headers keep things sane across machines", 10, height - 15);
+  popStyle();
+}
+
+// Function to broadcast a PImage over UDP with chunking
 void broadcast(PImage img) {
 
   // We need a buffered image to do the JPG encoding
@@ -51,28 +112,54 @@ void broadcast(PImage img) {
   bimg.setRGB( 0, 0, img.width, img.height, img.pixels, 0, img.width);
 
   // Need these output streams to get image as bytes for UDP communication
-  ByteArrayOutputStream baStream	= new ByteArrayOutputStream();
-  BufferedOutputStream bos		= new BufferedOutputStream(baStream);
+  ByteArrayOutputStream baStream        = new ByteArrayOutputStream();
+  BufferedOutputStream bos              = new BufferedOutputStream(baStream);
 
   // Turn the BufferedImage into a JPG and put it in the BufferedOutputStream
   // Requires try/catch
   try {
     ImageIO.write(bimg, "jpg", bos);
-  } 
+    bos.flush();
+  }
   catch (IOException e) {
     e.printStackTrace();
   }
 
   // Get the byte array, which we will send out via UDP!
-  byte[] packet = baStream.toByteArray();
+  byte[] frameBytes = baStream.toByteArray();
+  int totalLength = frameBytes.length;
+  int frameId = frameIdCounter++;
+  int chunkCount = max(1, (int) ceil((float) totalLength / (float) MAX_PAYLOAD));
 
-  // Send JPEG data as a datagram
-  println("Sending datagram with " + packet.length + " bytes");
-  try {
-    ds.send(new DatagramPacket(packet,packet.length, InetAddress.getByName("localhost"),clientPort));
-  } 
-  catch (Exception e) {
-    e.printStackTrace();
+  if (targetAddress == null) {
+    System.err.println("Target address not configured; skipping frame.");
+    return;
+  }
+
+  println("Sending frame " + frameId + " as " + chunkCount + " chunk(s) -> " + totalLength + " bytes");
+
+  for (int chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++) {
+    int offset = chunkIndex * MAX_PAYLOAD;
+    int remaining = totalLength - offset;
+    int payloadLength = min(remaining, MAX_PAYLOAD);
+
+    ByteBuffer buffer = ByteBuffer.allocate(HEADER_SIZE + payloadLength);
+    buffer.order(ByteOrder.BIG_ENDIAN);
+    buffer.putInt(frameId);
+    buffer.putInt(totalLength);
+    buffer.putShort((short) chunkIndex);
+    buffer.putShort((short) chunkCount);
+    buffer.putShort((short) payloadLength);
+    buffer.put(frameBytes, offset, payloadLength);
+
+    byte[] packet = buffer.array();
+
+    try {
+      DatagramPacket datagram = new DatagramPacket(packet, packet.length, targetAddress, clientPort);
+      ds.send(datagram);
+    }
+    catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 }
-


### PR DESCRIPTION
## Summary
- add runtime prompts to configure sender host and UDP ports in both receiver sketches so streams can move between machines without code edits
- add a frame header and chunking logic to the sender so JPEG payloads larger than 64KB are delivered as sequenced datagrams
- implement frame reassembly helpers and timeout-aware receive loops so both the single-threaded and threaded receivers drop or rebuild partial frames without freezing the UI

## Testing
- not run (Processing sketches)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691570083c908325887c85077d1adad4)