### PR TITLE
Improve videoRNDM movie scheduling reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Each folder holds a Processing sketch that targets a specific idea: ASCII camera
 | `vidControl` | Webcam motion detector that fires OSC messages describing how rowdy the scene is. | `processing.video`, `oscP5`, `netP5` | Sends OSC bundles (`none`, `tiny`, `some`, `lots`) to `127.0.0.1:12000`. Great companion to `vidPlay`. |
 | `vidPlay` | OSC-controlled movie playback that responds to the vibe levels from `vidControl`. | `processing.video`, `oscP5`, `netP5` | Supply the referenced video file (currently `ROBOTECH_REMASTERED_VOL_1_? copy.m4v`) in `data/`. Adjust the filename to match your actual asset. |
 | `videoFilters` | Keyboard-driven webcam filters for mirroring, sepia, posterization, and threshold effects. | `processing.video` | Use keys `v`, `m`, `s`, `f`, `y` to switch looks. Any other key resets to the raw feed. |
-| `videoRNDM` | Prototype for scheduling surprise video clips based on elapsed time. | `processing.video` | Set `stringNum` to a valid clip name before running—right now the sketch will crash without it. A teachable moment about initialization. |
+| `videoRNDM` | Prototype for scheduling surprise video clips based on elapsed time. | `processing.video` | Ships with a default clip ID (`00.mov`), auto-schedules new triggers, and swaps to fresh movies as the timer advances. Drop your numbered clips in `data/`. |
 
 ## Media file expectations
 | Sketch | Current filename(s) referenced in code | What to do |
@@ -46,7 +46,7 @@ Each folder holds a Processing sketch that targets a specific idea: ASCII camera
 | `bg_subMOV`, `bg_subMOV2` | `Untitled_1.mov` | Replace with your own clip but keep the filename or update the code. Drop it inside each sketch’s `data/` folder. |
 | `vidPlay` | `ROBOTECH_REMASTERED_VOL_1_? copy.m4v` | Rename your target file to something sane and edit the `new Movie` call to match. |
 | `sketch_190517a` | `0.mov` … `9.mov` (driven by `movTOTAL`) | Provide numbered clips or tweak the selector logic. |
-| `videoRNDM` | `stringNum + ".mov"` (uninitialized) | Set `stringNum` manually before `setup()` or refactor the sketch as described in its README. |
+| `videoRNDM` | `stringNum + ".mov"` (starts at `00.mov`) | Provide zero-padded clips (e.g. `00.mov`, `01.mov`). The sketch randomizes the next filename each time a trigger fires. |
 | `compositeVideoSim` | Image file defined by `filename`/`fileext` | Drop an image into the sketch folder and update the variables. |
 
 ## How to contribute or extend

--- a/videoRNDM/README.md
+++ b/videoRNDM/README.md
@@ -9,17 +9,17 @@ Prototype timer that randomly drops surprise video clips once the clock hits a t
 
 ## Ingredients
 - **Libraries:** `processing.video`.
-- **Media:** Provide a set of numbered clips (`00.mov`, `01.mov`, etc.) and set `stringNum` to a valid base name before `setup()` runs.
+- **Media:** Provide a set of numbered clips (`00.mov`, `01.mov`, etc.) inside a `data/` folder. The sketch bootstraps with clip `00.mov` and then chases fresh surprises.
 
 ## Run it
-1. Decide which clip should play first and set `stringNum = "00";` (for example) near the top of the sketch. Without this, `new Movie(this, stringNum+".mov")` will throw a null pointer.
-2. Drop the clips into the `data/` folder. The sketch expects zero-padded filenames when you call `nf(int(random(100)))`.
-3. Run the sketch. It captures the start time, picks `target_m` and `target_s`, and waits until the clock matches. Once triggered, it loads a new random clip and displays it.
+1. Drop the clips into the `data/` folder. The sketch expects zero-padded filenames because the randomizer uses `nf(int(random(100)), 2)`.
+2. Run the sketch. `setup()` locks the window to `size(640, 480)`, grabs the current time, primes the first playback, and schedules a future trigger.
+3. When the clock blows past that trigger, the sketch picks another clip name, spins up a new `Movie`, and queues another timestamp so the party keeps rolling.
 
 ## How it works
 - `startTOTAL` and `stopTOTAL` convert minutes/seconds into a single second count so you can measure differences easily.
 - `calculate()` updates the current minute (`cm`) and second (`cs`) offset from the start.
-- When the current offset matches the random target, the sketch chooses a new random filename with `nf(int(random(100)))` and plays it. This is deliberately sparse so you can expand the scheduler logic.
+- When the current offset passes the random target, the sketch chooses a new random filename with `nf(int(random(100)), 2)`, swaps to a fresh `Movie`, and schedules the next surprise.
 
 ## Remix it
 - Replace the time-based trigger with keyboard input, OSC messages, or sensor data.

--- a/videoRNDM/videoRNDM.pde
+++ b/videoRNDM/videoRNDM.pde
@@ -11,30 +11,60 @@ boolean isPlaying = false;
 Movie mov;
 
 float rnd;
-String stringNum;
+String stringNum = "00";
 
 void setup() {
+  size(640, 480);
   startcount = true;
   startSECOND=second();
   startMINUTE=minute();
   startTOTAL = startMINUTE*60 + startSECOND;
-  target_m = int(random(0, 8));
-  target_s = int(random(0, 59));
+  setNextTarget();
 
-  mov = new Movie(this, stringNum+".mov");
-  mov.play();
+  playClip(stringNum);
 }
 
 void draw() {
-
-  if (target_m == cm) {
-    if (target_s == cs) {
-      stringNum = nf(int(random(100)));
-
-      image(mov, 0, 0, width, height);
-    }
-  }
+  background(0);
   calculate();
+
+  if (shouldTrigger()) {
+    triggerNextClip();
+  }
+
+  if (mov != null && isPlaying) {
+    image(mov, 0, 0, width, height);
+  }
+}
+
+boolean shouldTrigger() {
+  return startcount && (cm > target_m || (cm == target_m && cs >= target_s));
+}
+
+void triggerNextClip() {
+  stringNum = nf(int(random(100)), 2);
+  playClip(stringNum);
+  setNextTarget();
+}
+
+void playClip(String clipId) {
+  if (mov != null) {
+    mov.stop();
+  }
+  mov = new Movie(this, clipId + ".mov");
+  mov.play();
+  isPlaying = true;
+}
+
+void setNextTarget() {
+  int deltaSeconds = int(random(1, 8 * 60 + 1));
+  int totalSeconds = (cm * 60 + cs) + deltaSeconds;
+  target_m = totalSeconds / 60;
+  target_s = totalSeconds % 60;
+}
+
+void movieEvent(Movie m) {
+  m.read();
 }
 
 void calculate()


### PR DESCRIPTION
## Summary
- initialize videoRNDM with a default clip ID, window size, and movieEvent handler
- randomize future triggers after each playback and keep frames rendering during draw
- document the new behavior in the sketch README and the root catalog

## Testing
- Not run (Processing sketches not executed in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915700e3c5883258fafb762acc4e545)