### PR TITLE
Document /motion OSC pipeline

### DIFF
--- a/vidControl/README.md
+++ b/vidControl/README.md
@@ -16,14 +16,14 @@ Motion-driven OSC controller: watch the webcam for movement and shout OSC messag
 1. Install `oscP5` and `netP5` via the Contribution Manager (they ship together).
 2. Open `vidControl.pde` in Processing, confirm the Video library is available, and place a receiver sketch/app on port `12000`.
 3. Hit Run. The webcam feed displays in the window to help with framing.
-4. Wave around. The sketch maps `presenceSum` (sum of RGB differences across the frame) into four ranges and sends OSC messages labelled `none`, `tiny`, `some`, or `lots`.
+4. Wave around. The sketch maps `presenceSum` (sum of RGB differences across the frame) into four ranges and sends OSC messages labelled `none`, `tiny`, `some`, or `lots`. It also spits out a normalized `/motion` float in the payload so downstream tools can dance along a continuous 0–1 curve—check the HUD overlay in `vidPlay` to watch that value breathe.
 
 ## How it works
 - Each frame, `presenceSum` accumulates the absolute difference between the current frame and the last stored `backgroundPixels`. Because the code updates `backgroundPixels[i] = currColor;` each iteration, it effectively measures per-frame change rather than difference from a static background.
-- The `map()` call squeezes `presenceSum` into 0–20. That value selects which OSC message to fire; the payload is a simple integer (`1`–`4`).
-- `frameRate(4);` throttles processing, making the OSC stream easier to digest and showing how frame rates affect responsiveness.
+- The `map()` call squeezes `presenceSum` into 0–20. That value selects which OSC message to fire; the payload is a simple integer (`1`–`4`) *and* the same measurement normalized to a 0–1 float published under `/motion`.
+- `frameRate(4);` throttles processing to 4 fps so receivers aren’t flooded; you still get a live-but-chill motion feed.
 
 ## Remix it
 - Capture a clean background image by pressing a key, then compare future frames against that snapshot for more stable results.
-- Send the motion metrics as continuous floats instead of discrete buckets.
+- Remix the `/motion` float before sending—try exponential curves, smoothing filters, or separate bands for each region of the frame.
 - Chain in OpenCV for blob detection so you only react to specific regions of the frame.

--- a/vidPlay/README.md
+++ b/vidPlay/README.md
@@ -16,14 +16,14 @@ An OSC-responsive movie player: it listens for vibe levels from `vidControl` and
 1. Place your desired video file into the sketch’s `data/` folder and update the filename in `setup()` if needed.
 2. Open `vidPlay.pde` in Processing with the Video and OSC libraries installed.
 3. Run the sketch. By default it loops the movie.
-4. Trigger OSC messages from `vidControl` (or another source) using address patterns `none`, `tiny`, `some`, and `lots`. Each message maps to a playback speed: reverse, slow, normal, and hype mode (1.85x).
+4. Trigger `/motion` floats from `vidControl` (or another source). The HUD strip at the bottom prints the live normalized value and the resulting speed so you can sanity-check the stream in real time.
 
 ## How it works
-- `oscEvent(OscMessage theOscMessage)` uses `checkAddrPattern` to compare the incoming message with each expected route. When matched, it updates `newSpeed`.
-- The `draw()` loop applies `mov.speed(newSpeed);` each frame and caches `oldSpeed` so unknown messages don’t crash playback—they simply reuse the previous speed.
-- There’s no payload validation yet, so this is a good platform for adding safety checks or supporting continuous float parameters.
+- `oscEvent(OscMessage theOscMessage)` now looks for `/motion`, clamps the float payload into 0–1, eases it with `pow(value, 1.5)`, then maps that eased value through `lerp(-0.5, 2.0, eased)` so chill moments coast in reverse and big spikes rocket forward.
+- The `draw()` loop applies `mov.speed(newSpeed);` each frame and paints a semi-transparent HUD so you can debug what OSC is doing without tailing the console.
+- There’s no payload validation yet beyond the clamp, so this is a good platform for adding safety checks or supporting additional continuous parameters.
 
 ## Remix it
-- Map OSC floats (`/speed`, `/scrub`) instead of discrete address patterns to gain finer control.
-- Display on-screen feedback for the current speed and message source.
+- Fork the easing curve: try `pow(value, 0.8)` for punchier attacks or cascade a low-pass filter before mapping speed.
+- Expand the HUD with color ramps, meters, or debug text so performers can read the room from across the stage.
 - Sync audio playback or route simultaneous OSC triggers to DMX/MIDI for multimedia shows.


### PR DESCRIPTION
## Summary
- describe the normalized `/motion` float published by vidControl and how it rides a 0–1 range at 4 fps
- explain how vidPlay consumes `/motion`, eases it with `pow(value, 1.5)`, and maps it via `lerp(-0.5, 2.0, eased)` with a HUD for debugging

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e30b8ae88325baed75cd5c9875e7)