### PR TITLE
Clarify MIDI mapping documentation for MidiVideoSyphonBeats

### DIFF
--- a/videoProcessing-midi-sync/ExampleMappings.md
+++ b/videoProcessing-midi-sync/ExampleMappings.md
@@ -1,2 +1,0 @@
-# ExampleMappings
-Placeholder for demonstration.

--- a/videoProcessing-midi-sync/README.md
+++ b/videoProcessing-midi-sync/README.md
@@ -27,4 +27,15 @@ Each folder is a straight-up Processing sketch. Drop the folder inside your Proc
 - The feedback buffer is intentionally lo-fi. Crank `CONFIG.feedbackMix` for smeary echoes or drop it to zero for crisp output.
 - `MidiVideoSyphonBeats` prints every CC/note it hears. Map those to real effects when you're ready to go deeper.
 
+## MIDI mapping reality check
+
+There isn't a secret preset hiding somewhere: `MidiVideoSyphonBeats` ships without any hard-coded CC or note bindings. The
+sketch just listens, reports the messages in the console, and expects you to wire those values to visuals in whatever host or
+loopback setup you're running. Treat the console spam as a live MIDI monitor. Once you know which knobs/faders/pads your
+controller is throwing, patch them downstream—Ableton, VDMX, custom Processing add-ons, whatever suits your rig.
+
+Need to bake in specific behaviour? Drop your controller logic straight into `noteOn()` or `controllerChange()` inside
+`MidiVideoSyphonBeats.pde`. Keep the changes in version control like the rest of your jam notes so future-you remembers why
+CC 74 suddenly triggers a blinding strobe.
+
 Pull requests with field notes, MIDI mappings, or screenshots of the rig mid-chaos are very welcome. Stay scrappy, keep the signal loud, and leave breadcrumbs for the next hacker digging through your notebooks.


### PR DESCRIPTION
## Summary
- remove the unused ExampleMappings placeholder file
- document the real MIDI mapping behaviour directly in the README with guidance on customising note/CC handling

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e320577c832585acc244b839cef4)