### PR TITLE
Fix ASCII timer reset and font loading

### DIFF
--- a/AsciiVideo_MiM/AsciiVideo_MiM.pde
+++ b/AsciiVideo_MiM/AsciiVideo_MiM.pde
@@ -53,7 +53,7 @@ void setup() {
   int count = video.width * video.height;
   //println(count);
 
-  font = loadFont("Moospaced-48.vlw");
+  font = loadFont("Monospaced-48.vlw");
 
   // for the 256 levels of brightness, distribute the letters across
   // the an array of 256 elements to use for the lookup
@@ -145,15 +145,15 @@ void draw() {
   if (actualSecs % 60 == 0) {
     restartSecs = actualSecs;
   }
-  if ((cMins == 1)) { 
+  if ((cMins == 1)) {
     saveFrame("########.jpg");
     reset = true;
   }
-  if (reset = true) {
+  if (reset) {
     restartSecs = actualSecs;
     cSecs = startSec;
     restartMins = actualMins;
-    cMins = restartMins;
+    cMins = startMin;
     reset = false;
   }
 }

--- a/AsciiVideo_MiM/README.md
+++ b/AsciiVideo_MiM/README.md
@@ -10,12 +10,12 @@ Render your face as a stream of punky ASCII glyphs and learn how to wrangle pixe
 ## Ingredients
 - **Libraries:** `processing.video`.
 - **Hardware:** Any webcam recognized by Processing.
-- **Assets:** The `data/` folder includes `Monospaced-48.vlw` and `UniversLTStd-Light-48.vlw`. The code currently calls `loadFont("Moospaced-48.vlw")`, so rename the file or update the line to make them match—another sneaky teachable bug.
+- **Assets:** The `data/` folder includes `Monospaced-48.vlw` and `UniversLTStd-Light-48.vlw`. The sketch now loads `Monospaced-48.vlw` directly so first-run font errors are a ghost of workshops past.
 
 ## Run it
 1. Open `AsciiVideo_MiM.pde` in Processing.
 2. Confirm the **Video** library is installed and grant webcam access when prompted.
-3. Hit Run and watch the glyphs stream in real time. Every minute the sketch *tries* to `saveFrame()`—because of the `if (reset = true)` typo the timer resets constantly, so use it to discuss debugging instead of relying on it.
+3. Hit Run and watch the glyphs stream in real time. Every minute the sketch now **actually** drops a `saveFrame()` thanks to the fixed `if (reset) { ... }` block, so you can teach boolean comparisons without sacrificing the auto-save demo.
 
 ## How it works
 - `Capture video = new Capture(this, 160, 120);` grabs a low-res feed to keep the ASCII grid manageable.
@@ -26,4 +26,8 @@ Render your face as a stream of punky ASCII glyphs and learn how to wrangle pixe
 ## Remix it
 - Swap in a custom font (drop a `.vlw` in `data/` and change `loadFont`).
 - Replace `max(r, g, b)` with a proper luma calculation (`0.2126*r + 0.7152*g + 0.0722*b`) and compare the results.
-- Fix the timer bug and make the auto-save trigger on a keyboard shortcut or motion detection.
+- Extend the timer logic—now that `reset` behaves, wire in a keyboard shortcut or motion trigger for manual capture bursts.
+
+## What changed and why
+- The minute-save routine no longer self-sabotages: `if (reset = true)` became a proper boolean guard so the reset logic waits for the flag and then clears it. That keeps the timer honest and the minute snapshots spaced out the way the syllabus promises.
+- `loadFont("Monospaced-48.vlw")` points straight at an existing asset, so students don't have to spelunk for a typo before they even see a pixel. Call it quality-of-life punk rock.


### PR DESCRIPTION
## Summary
- point the sketch at the existing Monospaced-48 font asset
- guard the reset block with a boolean check so the minute timer only resets after a save
- document the fixes so workshop notes highlight the intended behavior

## Testing
- not run (Processing CLI unavailable in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c294bf0c8325aee885a10f216caa)