### PR TITLE
Remove legacy filter mode from videoFilters

### DIFF
--- a/videoFilters/README.md
+++ b/videoFilters/README.md
@@ -23,11 +23,11 @@ A grab bag of webcam filter snippets for teaching pixel-level manipulation in Pr
    - Any other key – resets to the unfiltered feed.
 
 ## How it works
-- The sketch loops through every pixel on each draw, pulling values with `cam.get(i, j)` and writing back with `set(...)`. It’s not optimized, which makes it handy for discussing performance trade-offs.
+- The sketch leans into `loadPixels()`/`updatePixels()`, slurping the webcam frame into an `int[]` so we can mosh with pixels in-place without the legacy `cam.get()`/`set()` slog.
 - Each filter manipulates RGB channels differently, showing how simple arithmetic can produce stylized looks.
 - The `y` key toggles to HSB mode temporarily, illustrating how to juggle multiple color spaces in one frame.
 
 ## Remix it
-- Replace the nested loops with `loadPixels()`/`updatePixels()` for faster operations and show the speed difference.
+- Hack in easing between frames or tween between filter outputs so transitions feel less binary.
 - Add keyboard commands to blend between filters instead of switching abruptly.
 - Pipe the processed pixels into a `PGraphics` buffer so you can layer typography or UI on top.

--- a/videoFilters/videoFilters.pde
+++ b/videoFilters/videoFilters.pde
@@ -1,7 +1,6 @@
 import processing.video.*;
 
 Capture cam;
-boolean useLegacyMode = false;
 char activeFilter = ' ';
 
 void setup()
@@ -15,11 +14,6 @@ void setup()
 void draw() {
   if (cam.available()) {
     cam.read();
-  }
-
-  if (useLegacyMode) {
-    drawLegacyFilters();
-    return;
   }
 
   loadPixels();
@@ -43,11 +37,7 @@ void draw() {
 }
 
 void keyPressed() {
-  if (key == 'd' || key == 'D') {
-    useLegacyMode = !useLegacyMode;
-  } else {
-    activeFilter = key;
-  }
+  activeFilter = key;
 }
 
 void applyVerticalFlip() {
@@ -153,109 +143,4 @@ void applyHSBThreshold() {
 void copyCurrentFrame() {
   cam.loadPixels();
   arrayCopy(cam.pixels, pixels);
-}
-
-void drawLegacyFilters() {
-  char filter = Character.toLowerCase(activeFilter);
-  if (filter == 'v') {
-    for (int y = 0; y < height; y = y + 1) {
-      for (int X = 0; X < width; X = X + 1) {
-        color px = cam.get(X, y);
-        float r = red(px);
-        float g = green(px);
-        float b = blue(px);
-        color c = color(r, g, b);
-        set(X, height - y, c);
-      }
-    }
-  } else if (filter == 'm') {
-    for (int i = 0; i < width; i = i + 1) {
-      for (int j = 0; j < height; j = j + 1) {
-        color px = cam.get(i, j);
-        float r = red(px);
-        float g = green(px);
-        float b = blue(px);
-        color c = color(r, g, b);
-        set(width - i, j, c);
-      }
-    }
-  } else if (filter == 's') {
-    for (int i = 0; i < width; i = i + 1) {
-      for (int j = 0; j < height; j = j + 1) {
-        int sepiaAmount = 20;
-        color px = cam.get(i, j);
-        float r = red(px) + (2 * sepiaAmount);
-        float g = green(px) + sepiaAmount;
-        float b = blue(px) - sepiaAmount;
-        color c = color(r, g, b);
-        set(i, j, c);
-      }
-    }
-  } else if (filter == 'f') {
-    for (int i = 0; i < width; i = i + 1) {
-      for (int j = 0; j < height; j = j + 1) {
-        color px = cam.get(i, j);
-        float r = red(px);
-        float g = green(px);
-        float b = blue(px);
-        float s = r + g + b;
-
-        if (-1 < s && s < 182) {
-          r = 0;
-          g = 51;
-          b = 76;
-        }
-        if (181 < s && s < 364) {
-          r = 217;
-          g = 26;
-          b = 33;
-        }
-        if (363 < s && s < 546) {
-          r = 112;
-          g = 150;
-          b = 158;
-        }
-        if (545 < s && s < 766) {
-          r = 252;
-          g = 227;
-          b = 166;
-        }
-        colorMode(RGB);
-        color c = color(r, g, b);
-        set(i, j, c);
-      }
-    }
-  } else if (filter == 'y') {
-    for (int i = 0; i < width; i = i + 1) {
-      for (int j = 0; j < height; j = j + 1) {
-        color px = cam.get(i, j);
-        float r = red(px);
-        float g = green(px);
-        float b = blue(px);
-        float T = 0;
-        float C = (r + b + g) % 255;
-        if (C < 40) {
-          T = 0;
-        }
-        if (C > 39) {
-          T = 255;
-        }
-        colorMode(HSB);
-        color c = color(C, C, C, T);
-        set(i, j, c);
-        colorMode(RGB);
-      }
-    }
-  } else {
-    for (int i = 0; i < width; i = i + 1) {
-      for (int j = 0; j < height; j = j + 1) {
-        color px = cam.get(i, j);
-        float r = red(px);
-        float g = green(px);
-        float b = blue(px);
-        color c = color(r, g, b);
-        set(i, j, c);
-      }
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- remove the legacy mode flag and branch from `videoFilters.pde`
- simplify the keyboard handler so keys only pick filters
- refresh the README to explain the pixel-array workflow now that legacy paths are gone

## Testing
- not run (Processing sketch)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c29aa3608325ba4636b164973e98)